### PR TITLE
Update list of Third-party Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,8 @@ Please note that the software is not endorsed or certified by Lever.
 
 ### PHP
 * [mjacobus/lever-api-client](https://github.com/mjacobus/lever-api-client)
+
+### Gatsby - Blazing-fast static site generator for React
+* [mjacobus/lever-api-client](https://www.gatsbyjs.org/packages/gatsby-source-lever/)
+
+


### PR DESCRIPTION
Added [Gatsby - Blazing-fast static site generator for React](https://www.gatsbyjs.org/)
The link https://www.gatsbyjs.org/packages/gatsby-source-lever/ leads to 404 at the time of publishing this PR, the page will be online in a couple hours.

Main PR on Gatsby's repo is here : https://github.com/gatsbyjs/gatsby/pull/2042