### PR TITLE
[TOFU-1015]: Documentation - Add workplaceType

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ In JSON mode, each job posting is a JSON object with the following fields:
 | additionalPlain  | Optional closing content for the job posting (as plaintext). This may be an empty string.
 | hostedUrl   | A URL which points to Lever's hosted job posting page. Examples: [global][leverdemo-job-site-posting-global] / [EU][leverdemo-job-site-posting-eu]
 | applyUrl    | A URL which points to Lever's hosted application form to apply to the job posting. Examples: [global][leverdemo-job-site-posting-application-global] / [EU][leverdemo-job-site-posting-application-eu]
+| workplaceType    | Describes the primary workplace environment for a job posting. May be one of `unspecified`, `on-site`, `remote`, or `hybrid`. Not filterable. <br /> Note: to be released in waved rollouts starting October, 2022.
 
 ## Get a specific job posting
 


### PR DESCRIPTION
## Context
Adding workplaceType to documentation under get-list-of-job-postings

## Related Links and PRs

- JIRA: [TOFU-1015](https://leverapp.atlassian.net/browse/TOFU-1015?atlOrigin=eyJpIjoiNGU1ZmU0MWVkOTYyNDU0MmE4NjRlOWYxZDY5NjJmNGYiLCJwIjoiaiJ9)

## Screenshots
Before 
<img width="1050" alt="Screen Shot 2022-09-07 at 10 39 23 AM" src="https://user-images.githubusercontent.com/84153577/188908997-17e4b8f8-bff0-4177-96d8-8e06f7d9f771.png">

After 
<img width="1041" alt="Screen Shot 2022-09-07 at 10 40 02 AM" src="https://user-images.githubusercontent.com/84153577/188909021-0fbe6758-4393-4511-90c0-29a4712e6b7f.png">


