### PR TITLE
[GOLD-2536] Add docs for salaryRange fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ In JSON mode, each job posting is a JSON object with the following fields:
 | hostedUrl   | A URL which points to Lever's hosted job posting page. Examples: [global][leverdemo-job-site-posting-global] / [EU][leverdemo-job-site-posting-eu]
 | applyUrl    | A URL which points to Lever's hosted application form to apply to the job posting. Examples: [global][leverdemo-job-site-posting-application-global] / [EU][leverdemo-job-site-posting-application-eu]
 | workplaceType    | Describes the primary workplace environment for a job posting. May be one of `unspecified`, `on-site`, `remote`, or `hybrid`. Not filterable. <br /> Note: to be released in waved rollouts starting October, 2022.
-| salaryRange  | Object with `currency`, `interval`, `min`, and `max`.  This field is optional.  <br /> Note: to be released in waved rollouts starting mid February, 2023.
+| salaryRange  | Object with `currency`, `interval`, `min`, and `max`.  This field is optional.  In XML mode this field is parsed into a string.<br /> Note: to be released in waved rollouts starting mid February, 2023.
 | salaryDescription | Optional description for the Salary range (as styled HTML).  <br /> Note: to be released in waved rollouts starting mid February, 2023.
 | salaryDescriptionPlain | Optional description for the Salary range (as plainText).  <br /> Note: to be released in waved rollouts starting mid February, 2023.
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ In JSON mode, each job posting is a JSON object with the following fields:
 | hostedUrl   | A URL which points to Lever's hosted job posting page. Examples: [global][leverdemo-job-site-posting-global] / [EU][leverdemo-job-site-posting-eu]
 | applyUrl    | A URL which points to Lever's hosted application form to apply to the job posting. Examples: [global][leverdemo-job-site-posting-application-global] / [EU][leverdemo-job-site-posting-application-eu]
 | workplaceType    | Describes the primary workplace environment for a job posting. May be one of `unspecified`, `on-site`, `remote`, or `hybrid`. Not filterable. <br /> Note: to be released in waved rollouts starting October, 2022.
-| salaryRange  | Object with `currency`, `interval`, `min`, and `max`.  This field is optional.
-| salaryDescription | Optional description for the Salary range (as styled HTML).
-| salaryDescriptionPlain | Optional description for the Salary range (as plainText).
+| salaryRange  | Object with `currency`, `interval`, `min`, and `max`.  This field is optional.  <br /> Note: to be released in waved rollouts starting mid February, 2023.
+| salaryDescription | Optional description for the Salary range (as styled HTML).  <br /> Note: to be released in waved rollouts starting mid February, 2023.
+| salaryDescriptionPlain | Optional description for the Salary range (as plainText).  <br /> Note: to be released in waved rollouts starting mid February, 2023.
 
 ## Get a specific job posting
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ In JSON mode, each job posting is a JSON object with the following fields:
 | hostedUrl   | A URL which points to Lever's hosted job posting page. Examples: [global][leverdemo-job-site-posting-global] / [EU][leverdemo-job-site-posting-eu]
 | applyUrl    | A URL which points to Lever's hosted application form to apply to the job posting. Examples: [global][leverdemo-job-site-posting-application-global] / [EU][leverdemo-job-site-posting-application-eu]
 | workplaceType    | Describes the primary workplace environment for a job posting. May be one of `unspecified`, `on-site`, `remote`, or `hybrid`. Not filterable. <br /> Note: to be released in waved rollouts starting October, 2022.
+| salaryRange  | Object with `currency`, `interval`, `min`, and `max`.  This field is optional.
+| salaryDescription | Optional description for the Salary range (as styled HTML).
+| salaryDescriptionPlain | Optional description for the Salary range (as plainText).
 
 ## Get a specific job posting
 


### PR DESCRIPTION
Add docs in the README to indicate the addition of `salaryRange`, `salaryDesciption`, and `salaryDescriptionPlain`

https://github.com/lever/postings2/pull/662
https://github.com/lever/postings-serialization/pull/31

![image](https://user-images.githubusercontent.com/85203514/207736275-d634ca35-d227-41e7-99fa-1b4d0bbc2819.png)

